### PR TITLE
extra DL validation rule for OR 

### DIFF
--- a/regex.json
+++ b/regex.json
@@ -266,11 +266,10 @@
     ]
   },
   "OR": {
-    "rule": "(^[0-9]{1,9}$)|(^[AB][0-9]{6}$)",
+    "rule": "(^[0-9]{1,9}$)|(^[A-Za-z][0-9]{6,7}$)",
     "description": [
       "1-9 Numeric",
-      "A+6 Numeric",
-      "B+6 Numeric"
+      "One Alpha + 6-7 Numberic"
     ]
   },
   "PA": {


### PR DESCRIPTION
https://app.asana.com/0/1162165312581290/1199602489729422/f

OR has updated DL format according to https://www.mvrdecoder.com/content/drvlicformats.aspx but is not included in the usdl-regex rules.